### PR TITLE
Public `Register()` + new `Configure()`

### DIFF
--- a/src/StructureMap.Microsoft.DependencyInjection/ContainerExtensions.cs
+++ b/src/StructureMap.Microsoft.DependencyInjection/ContainerExtensions.cs
@@ -63,21 +63,19 @@ namespace StructureMap
             ((Registry) config).Populate(descriptors, checkDuplicateCalls);
         }
 
-        /// <summary>
-        /// Populates the registry using the specified service descriptors.
-        /// </summary>
-        /// <remarks>
-        /// This method should only be called once per container.
-        /// </remarks>
-        /// <param name="registry">The registry.</param>
-        /// <param name="descriptors">The service descriptors.</param>
+        /// <inheritdoc cref="Populate(Registry, IEnumerable{ServiceDescriptor}, bool)"/>
         public static void Populate(this Registry registry, IEnumerable<ServiceDescriptor> descriptors)
         {
             registry.Populate(descriptors, checkDuplicateCalls: false);
         }
 
         /// <summary>
-        /// Populates the registry using the specified service descriptors.
+        /// Populates the registry using the specified service descriptors, plus:
+        /// <list type="bullet">
+        ///   <item><see cref="AspNetConstructorSelector"/></item>
+        ///   <item><see cref="StructureMapServiceProvider"/> as per-container <see cref="IServiceProvider"/></item>
+        ///   <item><see cref="StructureMapServiceScopeFactory"/> as per-container <see cref="IServiceScopeFactory"/></item>
+        /// </list>
         /// </summary>
         /// <remarks>
         /// This method should only be called once per container.

--- a/src/StructureMap.Microsoft.DependencyInjection/ContainerExtensions.cs
+++ b/src/StructureMap.Microsoft.DependencyInjection/ContainerExtensions.cs
@@ -115,6 +115,17 @@ namespace StructureMap
         }
 
         /// <summary>
+        /// Configures <paramref name="registry"/> with <paramref name="configure"/>.
+        /// </summary>
+        /// <remarks>
+        /// Unlike <see cref="Populate(Registry, IEnumerable{ServiceDescriptor})"/>, this method may be be called more than once per container.
+        /// </remarks>
+        /// <param name="registry">The registry.</param>
+        /// <param name="configure">The service configurator.</param>
+        public static void Configure(this IProfileRegistry registry, Func<IServiceCollection, IServiceCollection> configure) =>
+            registry.Register(configure(new SimpleServiceCollection()));
+
+        /// <summary>
         /// Registers the specified service descriptors.
         /// </summary>
         /// <remarks>
@@ -161,5 +172,11 @@ namespace StructureMap
         }
 
         private interface IMarkerInterface { }
+
+        // We don't depend on the package that declares ServiceCollection,
+        // but even if we did this is slightly better because we don't need its IsReadOnly checks
+        private class SimpleServiceCollection : List<ServiceDescriptor>, IServiceCollection
+        {
+        }
     }
 }

--- a/src/StructureMap.Microsoft.DependencyInjection/ContainerExtensions.cs
+++ b/src/StructureMap.Microsoft.DependencyInjection/ContainerExtensions.cs
@@ -114,7 +114,15 @@ namespace StructureMap
             }
         }
 
-        private static void Register(this IProfileRegistry registry, IEnumerable<ServiceDescriptor> descriptors)
+        /// <summary>
+        /// Registers the specified service descriptors.
+        /// </summary>
+        /// <remarks>
+        /// Unlike <see cref="Populate(Registry, IEnumerable{ServiceDescriptor})"/>, this method may be be called more than once per container.
+        /// </remarks>
+        /// <param name="registry">The registry.</param>
+        /// <param name="descriptors">The service descriptors.</param>
+        public static void Register(this IProfileRegistry registry, IEnumerable<ServiceDescriptor> descriptors)
         {
             foreach (var descriptor in descriptors)
             {

--- a/src/StructureMap.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/StructureMap.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace StructureMap
 {
@@ -13,5 +14,13 @@ namespace StructureMap
         {
             return services.AddSingleton<IServiceProviderFactory<Registry>>(new StructureMapServiceProviderFactory(registry));
         }
+
+        /// <summary>
+        /// Configures <paramref name="services"/> with <paramref name="configure"/>.
+        /// </summary>
+        /// <param name="services">The service collection.</param>
+        /// <param name="configure">The service configurator.</param>
+        /// <returns>The result of <paramref name="configure"/>, which should be <paramref name="services"/>.</returns>
+        public static IServiceCollection Configure(this IServiceCollection services, Func<IServiceCollection, IServiceCollection> configure) => configure(services);
     }
 }

--- a/test/StructureMap.Microsoft.DependencyInjection.Tests/StructureMapContainerTests.cs
+++ b/test/StructureMap.Microsoft.DependencyInjection.Tests/StructureMapContainerTests.cs
@@ -38,6 +38,29 @@ namespace StructureMap.Microsoft.DependencyInjection.Tests
             return container.GetInstance<IServiceProvider>();
         }
 
+        [Fact]
+        public void ConfigureAndRegisterDoNotPreventPopulate()
+        {
+            var services = new ServiceCollection();
+            services.AddTransient<IFakeService, FakeService>();
+
+            var container = new Container();
+            container.Configure(config =>
+            {
+                config.Register(services);
+                config.Register(services);
+
+                config.Configure(ctx => ctx.AddScoped<IFakeScopedService, FakeService>());
+                config.Configure(ctx => ctx.AddSingleton<IFakeSingletonService, FakeService>());
+
+                config.Populate(services, checkDuplicateCalls: true);
+            });
+
+            Assert.NotNull(container.GetInstance<IFakeService>());
+            Assert.NotNull(container.GetInstance<IFakeSingletonService>());
+            Assert.NotNull(container.GetInstance<IFakeScopedService>());
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]


### PR DESCRIPTION
`Populate()` isn't meant to be called more than once because it adds `IServiceProvider` and such, but for migration purposes it would be useful to be able to register additional collections of services.

---

After more tinkering, I also propose a new `Configure()` method to support the common `IServiceCollection AddWhatever(this IServiceCollection services)` pattern.

A `Registry` migration could look like this:

```diff
 public class MyRegistry : Registry
 {
-    public MyRegistry()
+    public MyRegistry() => this.Configure(Register);
+
+    public static IServiceCollection Register(IServiceCollection services)
     {
-        For<IService>().Singleton().Use<Service>();
+        services.AddSingleton<IService, Service>();
         // …
+        return services;
     }
 }
```

`Include<MyRegistry>()` will continue to work, but parent registries can migrate incrementally:

```diff
 public class MyParentRegistry : Registry
 {
     public MyParentRegistry()
     {
-        IncludeRegistry<MyRegistry>();
+        this.Configure(MyRegistry.Register);
         IncludeRegistry<MyOtherRegistry>();
     }
 }
```

I also included a `Configure(this IServiceCollection)` to allow these non-extension methods to play nicely until `Registry` support is no longer required and the class can be made `static`, e.g.

```csharp
services
    .AddStuff()
    .Configure(MyRegistry.Register)
    .AddMoreStuff();
```