### PR TITLE
Ensure container has `IServiceProvider`/`IServiceScopeFactory`

### DIFF
--- a/src/StructureMap.Microsoft.DependencyInjection/ContainerExtensions.cs
+++ b/src/StructureMap.Microsoft.DependencyInjection/ContainerExtensions.cs
@@ -95,14 +95,6 @@ namespace StructureMap
 
             registry.Policies.ConstructorSelector<AspNetConstructorSelector>();
 
-            registry.For<IServiceProvider>()
-                .LifecycleIs(Lifecycles.Container)
-                .Use<StructureMapServiceProvider>();
-
-            registry.For<IServiceScopeFactory>()
-                .LifecycleIs(Lifecycles.Container)
-                .Use<StructureMapServiceScopeFactory>();
-
             registry.Register(descriptors);
         }
 
@@ -135,6 +127,16 @@ namespace StructureMap
         /// <param name="descriptors">The service descriptors.</param>
         public static void Register(this IProfileRegistry registry, IEnumerable<ServiceDescriptor> descriptors)
         {
+            // Required for factory service descriptors
+            registry.For<IServiceProvider>()
+                .LifecycleIs(Lifecycles.Container)
+                .UseIfNone<StructureMapServiceProvider>();
+
+            // Required for scoped service descriptors
+            registry.For<IServiceScopeFactory>()
+                .LifecycleIs(Lifecycles.Container)
+                .UseIfNone<StructureMapServiceScopeFactory>();
+
             foreach (var descriptor in descriptors)
             {
                 registry.Register(descriptor);

--- a/test/StructureMap.Microsoft.DependencyInjection.Tests/StructureMapContainerTests.cs
+++ b/test/StructureMap.Microsoft.DependencyInjection.Tests/StructureMapContainerTests.cs
@@ -61,6 +61,41 @@ namespace StructureMap.Microsoft.DependencyInjection.Tests
             Assert.NotNull(container.GetInstance<IFakeScopedService>());
         }
 
+        [Fact]
+        public void ConfigureDoesNotRequirePopulate()
+        {
+            var container = new Container();
+            container.Configure(config =>
+            {
+                config.Configure(services => services
+                    .AddScoped<IFakeScopedService>(_ => new FakeService())
+                );
+            });
+
+            Assert.NotNull(container.GetInstance<IFakeScopedService>());
+
+            Assert.NotNull(container.GetInstance<IServiceProvider>());
+            Assert.NotNull(container.GetInstance<IServiceScopeFactory>());
+        }
+
+        [Fact]
+        public void RegisterDoesNotRequirePopulate()
+        {
+            var container = new Container();
+            container.Configure(config =>
+            {
+                var services = new ServiceCollection()
+                    .AddScoped<IFakeScopedService>(_ => new FakeService());
+
+                config.Register(services);
+            });
+
+            Assert.NotNull(container.GetInstance<IFakeScopedService>());
+
+            Assert.NotNull(container.GetInstance<IServiceProvider>());
+            Assert.NotNull(container.GetInstance<IServiceScopeFactory>());
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]


### PR DESCRIPTION
Testing a `Registry` that uses `Configure()`/`Register()` (from #2) should not depend on calling `Populate()` for factory or scoped service descriptors to work.

> StructureMap.StructureMapConfigurationException:
> No default Instance is registered and cannot be automatically determined for type 'System.IServiceProvider'

This isn't a huge problem in tests, but as I noted below we plan to convert registries that are only used in legacy apps that might never call `Populate()`.

### Workaround

```
var container = new Container();
container.Configure(c =>
{
    c.IncludeRegistry<MyRegistry>();
    c.Populate([]);
});
container.AssertConfigurationIsValid();
```

Not terrible, just annoying.