### PR TITLE
v3: Provide `IServiceProviderIsService`

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.2.0</VersionPrefix>
+    <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>dustinsoftware</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/src/StructureMap.Microsoft.DependencyInjection/ContainerExtensions.cs
+++ b/src/StructureMap.Microsoft.DependencyInjection/ContainerExtensions.cs
@@ -137,6 +137,11 @@ namespace StructureMap
                 .LifecycleIs(Lifecycles.Container)
                 .UseIfNone<StructureMapServiceScopeFactory>();
 
+            // Added in MEDI v6
+            registry.For<IServiceProviderIsService>()
+                .LifecycleIs(Lifecycles.Container)
+                .UseIfNone<StructureMapServiceProviderIsService>();
+
             foreach (var descriptor in descriptors)
             {
                 registry.Register(descriptor);

--- a/src/StructureMap.Microsoft.DependencyInjection/StructureMap.Microsoft.DependencyInjection.csproj
+++ b/src/StructureMap.Microsoft.DependencyInjection/StructureMap.Microsoft.DependencyInjection.csproj
@@ -6,6 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="StructureMap" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/src/StructureMap.Microsoft.DependencyInjection/StructureMapServiceProviderIsService.cs
+++ b/src/StructureMap.Microsoft.DependencyInjection/StructureMapServiceProviderIsService.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace StructureMap
+{
+    public sealed class StructureMapServiceProviderIsService : IServiceProviderIsService
+    {
+        private readonly IContainer _container;
+
+        public StructureMapServiceProviderIsService(IContainer container) => _container = container;
+
+        // https://github.com/dotnet/dotnet/blob/d25d3482f4c3c509977cc4d959c80cb78b6ad9c8/src/runtime/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs#L778-L803
+        public bool IsService(Type serviceType)
+        {
+            if (serviceType is null)
+            {
+                throw new ArgumentNullException(nameof(serviceType));
+            }
+
+            // Querying for an open generic should return false (they aren't resolvable)
+            if (serviceType.IsGenericTypeDefinition)
+            {
+                return false;
+            }
+
+            if (_container.Model.HasDefaultImplementationFor(serviceType))
+            {
+                return true;
+            }
+
+
+            if (serviceType.IsConstructedGenericType && serviceType.GetGenericTypeDefinition() is Type genericDefinition)
+            {
+                // We special case IEnumerable since it isn't explicitly registered in the container
+                // yet we can manifest instances of it when requested.
+                return genericDefinition == typeof(IEnumerable<>) ||
+                    _container.Model.HasDefaultImplementationFor(genericDefinition);
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/StructureMap.Microsoft.DependencyInjection/StructureMapServiceProviderIsService.cs
+++ b/src/StructureMap.Microsoft.DependencyInjection/StructureMapServiceProviderIsService.cs
@@ -29,13 +29,11 @@ namespace StructureMap
                 return true;
             }
 
-
             if (serviceType.IsConstructedGenericType && serviceType.GetGenericTypeDefinition() is Type genericDefinition)
             {
                 // We special case IEnumerable since it isn't explicitly registered in the container
                 // yet we can manifest instances of it when requested.
-                return genericDefinition == typeof(IEnumerable<>) ||
-                    _container.Model.HasDefaultImplementationFor(genericDefinition);
+                return genericDefinition == typeof(IEnumerable<>);
             }
 
             return false;

--- a/test/StructureMap.Microsoft.DependencyInjection.Tests/StructureMap.Microsoft.DependencyInjection.Tests.csproj
+++ b/test/StructureMap.Microsoft.DependencyInjection.Tests/StructureMap.Microsoft.DependencyInjection.Tests.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/test/StructureMap.Microsoft.DependencyInjection.Tests/StructureMapContainerTests.cs
+++ b/test/StructureMap.Microsoft.DependencyInjection.Tests/StructureMapContainerTests.cs
@@ -43,6 +43,7 @@ namespace StructureMap.Microsoft.DependencyInjection.Tests
         {
             var services = new ServiceCollection();
             services.AddTransient<IFakeService, FakeService>();
+            services.AddSingleton<IComparer<string>>(StringComparer.OrdinalIgnoreCase);
 
             var container = new Container();
             container.Configure(config =>
@@ -67,6 +68,25 @@ namespace StructureMap.Microsoft.DependencyInjection.Tests
 
             Assert.False(spis.IsService(typeof(FakeService)));
             Assert.False(spis.IsService(typeof(IFakeServiceInstance)));
+
+            // Open generics never resolve
+            Assert.False(spis.IsService(typeof(IComparer<>)));
+            Assert.False(spis.IsService(typeof(IEnumerable<>)));
+
+            // Registered closed generic does resolve
+            Assert.True(spis.IsService(typeof(IComparer<string>)));
+
+            // Unregistered closed generic does not resolve
+            Assert.False(spis.IsService(typeof(IComparer<IFakeService>)));
+
+            // IEnumerable<> of registered types does resolve
+            Assert.True(spis.IsService(typeof(IEnumerable<IFakeService>)));
+            Assert.True(spis.IsService(typeof(IEnumerable<IFakeScopedService>)));
+            Assert.True(spis.IsService(typeof(IEnumerable<IFakeSingletonService>)));
+
+            // IEnumerable<> of unregistered types also resolves
+            Assert.True(spis.IsService(typeof(IEnumerable<FakeService>)));
+            Assert.True(spis.IsService(typeof(IEnumerable<IFakeServiceInstance>)));
         }
 
         [Fact]

--- a/test/StructureMap.Microsoft.DependencyInjection.Tests/StructureMapContainerTests.cs
+++ b/test/StructureMap.Microsoft.DependencyInjection.Tests/StructureMapContainerTests.cs
@@ -12,6 +12,8 @@ namespace StructureMap.Microsoft.DependencyInjection.Tests
 {
     public class StructureMapContainerTests : DependencyInjectionSpecificationTests
     {
+        public override bool SupportsIServiceProviderIsService => false;
+
         // The following tests don't pass with the SM adapter...
         private static readonly string[] SkippedTests =
         {

--- a/test/StructureMap.Microsoft.DependencyInjection.Tests/StructureMapContainerTests.cs
+++ b/test/StructureMap.Microsoft.DependencyInjection.Tests/StructureMapContainerTests.cs
@@ -12,8 +12,6 @@ namespace StructureMap.Microsoft.DependencyInjection.Tests
 {
     public class StructureMapContainerTests : DependencyInjectionSpecificationTests
     {
-        public override bool SupportsIServiceProviderIsService => false;
-
         // The following tests don't pass with the SM adapter...
         private static readonly string[] SkippedTests =
         {
@@ -61,6 +59,14 @@ namespace StructureMap.Microsoft.DependencyInjection.Tests
             Assert.NotNull(container.GetInstance<IFakeService>());
             Assert.NotNull(container.GetInstance<IFakeSingletonService>());
             Assert.NotNull(container.GetInstance<IFakeScopedService>());
+
+            var spis = container.GetInstance<IServiceProviderIsService>();
+            Assert.True(spis.IsService(typeof(IFakeService)));
+            Assert.True(spis.IsService(typeof(IFakeScopedService)));
+            Assert.True(spis.IsService(typeof(IFakeSingletonService)));
+
+            Assert.False(spis.IsService(typeof(FakeService)));
+            Assert.False(spis.IsService(typeof(IFakeServiceInstance)));
         }
 
         [Fact]
@@ -77,6 +83,7 @@ namespace StructureMap.Microsoft.DependencyInjection.Tests
             Assert.NotNull(container.GetInstance<IFakeScopedService>());
 
             Assert.NotNull(container.GetInstance<IServiceProvider>());
+            Assert.NotNull(container.GetInstance<IServiceProviderIsService>());
             Assert.NotNull(container.GetInstance<IServiceScopeFactory>());
         }
 
@@ -95,6 +102,7 @@ namespace StructureMap.Microsoft.DependencyInjection.Tests
             Assert.NotNull(container.GetInstance<IFakeScopedService>());
 
             Assert.NotNull(container.GetInstance<IServiceProvider>());
+            Assert.NotNull(container.GetInstance<IServiceProviderIsService>());
             Assert.NotNull(container.GetInstance<IServiceScopeFactory>());
         }
 


### PR DESCRIPTION
MEDI v6 adds [`IServiceProviderIsService`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.iserviceproviderisservice), which a handful of our projects have (naively) implemented to satisfy https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.ApiExplorer. Might as well implement once with passing specs.